### PR TITLE
Fix SQLAlchemy Warning

### DIFF
--- a/statscache_plugins/volume/by_category.py
+++ b/statscache_plugins/volume/by_category.py
@@ -17,13 +17,16 @@ class PluginMixin(VolumePluginMixin):
     """
 
     def make_model(self):
-        class Result(statscache.plugins.BaseModel):
-            __tablename__ = 'data_volume_by_category_%s' % self.frequency
-            timestamp = sa.Column(sa.DateTime, nullable=False, index=True)
-            volume = sa.Column(sa.Integer, nullable=False)
-            category = sa.Column(sa.UnicodeText, nullable=False, index=True)
+        freq = str(self.frequency)
 
-        return Result
+        return type('VolumeByCategory' + freq + 'Model',
+                    (statscache.plugins.BaseModel,),
+                    {
+                        '__tablename__': 'data_volume_by_category_' + freq,
+                        'timestamp': sa.Column(sa.DateTime, nullable=False, index=True),
+                        'volume': sa.Column(sa.Integer, nullable=False),
+                        'category': sa.Column(sa.UnicodeText, nullable=False, index=True),
+                    })
 
     def handle(self, session, messages):
         volumes = collections.defaultdict(int)

--- a/statscache_plugins/volume/by_package.py
+++ b/statscache_plugins/volume/by_package.py
@@ -17,13 +17,16 @@ class PluginMixin(VolumePluginMixin):
     """
 
     def make_model(self):
-        class Result(statscache.plugins.BaseModel):
-            __tablename__ = 'data_volume_by_package_%s' % self.frequency
-            timestamp = sa.Column(sa.DateTime, nullable=False, index=True)
-            volume = sa.Column(sa.Integer, nullable=False)
-            package = sa.Column(sa.UnicodeText, nullable=False, index=True)
+        freq = str(self.frequency)
 
-        return Result
+        return type('VolumeByPackage' + freq + 'Model',
+                    (statscache.plugins.BaseModel,),
+                    {
+                        '__tablename__': 'data_volume_by_package_' + freq,
+                        'timestamp': sa.Column(sa.DateTime, nullable=False, index=True),
+                        'volume': sa.Column(sa.Integer, nullable=False),
+                        'package': sa.Column(sa.UnicodeText, nullable=False, index=True),
+                    })
 
     def handle(self, session, messages):
         volumes = collections.defaultdict(int)

--- a/statscache_plugins/volume/by_topic.py
+++ b/statscache_plugins/volume/by_topic.py
@@ -16,13 +16,16 @@ class PluginMixin(VolumePluginMixin):
     """
 
     def make_model(self):
-        class Result(statscache.plugins.BaseModel):
-            __tablename__ = 'data_volume_by_topic_%s' % self.frequency
-            timestamp = sa.Column(sa.DateTime, nullable=False, index=True)
-            volume = sa.Column(sa.Integer, nullable=False)
-            topic = sa.Column(sa.UnicodeText, nullable=False, index=True)
+        freq = str(self.frequency)
 
-        return Result
+        return type('VolumeByTopic' + freq + 'Model',
+                    (statscache.plugins.BaseModel,),
+                    {
+                        '__tablename__': 'data_volume_by_topic_' + freq,
+                        'timestamp': sa.Column(sa.DateTime, nullable=False, index=True),
+                        'volume': sa.Column(sa.Integer, nullable=False),
+                        'topic': sa.Column(sa.UnicodeText, nullable=False, index=True),
+                    })
 
     def handle(self, session, messages):
         volumes = collections.defaultdict(int)

--- a/statscache_plugins/volume/by_user.py
+++ b/statscache_plugins/volume/by_user.py
@@ -17,13 +17,16 @@ class PluginMixin(VolumePluginMixin):
     """
 
     def make_model(self):
-        class Result(statscache.plugins.BaseModel):
-            __tablename__ = 'data_volume_by_user_%s' % self.frequency
-            timestamp = sa.Column(sa.DateTime, nullable=False, index=True)
-            volume = sa.Column(sa.Integer, nullable=False)
-            user = sa.Column(sa.UnicodeText, nullable=False, index=True)
+        freq = str(self.frequency)
 
-        return Result
+        return type('VolumeByUser' + freq + 'Model',
+                    (statscache.plugins.BaseModel,),
+                    {
+                        '__tablename__': 'data_volume_by_user_' + freq,
+                        'timestamp': sa.Column(sa.DateTime, nullable=False, index=True),
+                        'volume': sa.Column(sa.Integer, nullable=False),
+                        'user': sa.Column(sa.UnicodeText, nullable=False, index=True),
+                    })
 
     def handle(self, session, messages):
         volumes = collections.defaultdict(int)

--- a/statscache_plugins/volume/simple.py
+++ b/statscache_plugins/volume/simple.py
@@ -17,9 +17,13 @@ class PluginMixin(VolumePluginMixin):
     """
 
     def make_model(self):
-        class Result(statscache.plugins.ScalarModel):
-            __tablename__ = 'data_volume_%s' % self.frequency
-        return Result
+        freq = str(self.frequency)
+
+        return type('Volume' + freq + 'Model',
+                    (statscache.plugins.ScalarModel,),
+                    {
+                        '__tablename__': 'data_volume_' + freq,
+                    })
 
     def handle(self, session, messages):
         volumes = collections.defaultdict(int)


### PR DESCRIPTION
This fixes the source of warnings like the one below:

```
 .../sqlalchemy/ext/declarative/clsregistry.py:120: SAWarning: This declarative base already contains a class with the same class name and module name as statscache_plugins.volume.by_category.Result, and will be replaced in the string-lookup table
```

Since each plugin stores its statistics through SQLAlchemy, each plugin uses a
declarative model derived from either `BaseModel` or `ScalarModel` in
`statscache.plugins`. SQLAlchemy stores these by mapping the model's qualified
class name as a key in a lookup table with `sqlalchemy.schema.Table` objects.
SQLAlchemy warns that reusing a qualified class name overrides the previous
entries. There can be cases in which SQLAlchemy ends up grabbing the
wrong table for a given model. This scenario is dependent on how SQLAlchemy
works, so it's best to not expose ourselves to that possibility. Therefore, we need
to dynamically generate the model classes, with unique names, for each instance
of a plugin (i.e., for each time frequency).
