### PR TITLE
Dynamic scheduling based on plugins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,12 @@ setup(
     ],
     entry_points={
         'statscache.plugin': [
-            "volume = statscache_plugins.volume.simple",
-            "releng = statscache_plugins.releng",
-            #"volume_by_topic = statscache_plugins.volume.by_topic",
-            "volume_by_category = statscache_plugins.volume.by_category",
-            #"volume_by_user = statscache_plugins.volume.by_user",
-            #"volume_by_package = statscache_plugins.volume.by_package",
+            "volume = statscache_plugins.volume.simple:plugins",
+            "releng = statscache_plugins.releng:Plugin",
+            #"volume_by_topic = statscache_plugins.volume.by_topic:plugins",
+            "volume_by_category = statscache_plugins.volume.by_category:plugins",
+            #"volume_by_user = statscache_plugins.volume.by_user:plugins",
+            #"volume_by_package = statscache_plugins.volume.by_package:plugins",
         ]
     },
 )

--- a/statscache_plugins/releng/__init__.py
+++ b/statscache_plugins/releng/__init__.py
@@ -138,12 +138,12 @@ class Plugin(statscache.plugins.BasePlugin):
             }
         }
 
-    def handle(self, session, messages):
+    def handle(self, session, timestamp, messages):
         rows = []
         try:
             for plugin in self._plugins:
                 try:
-                    rows.extend(plugin.handle(session, messages) or [])
+                    rows.extend(plugin.handle(session, timestamp, messages) or [])
                 except Exception as e:
                     log.exception(
                         "Error in releng plugin '{}': {}".format(

--- a/statscache_plugins/releng/__init__.py
+++ b/statscache_plugins/releng/__init__.py
@@ -14,6 +14,7 @@ class Plugin(statscache.plugins.BasePlugin):
     Recent release engineering event logs to be used for rendering
     release engineering dashboard.
     """
+    frequency = statscache.plugins.Frequency(minutes=5)
     datagrepper_endpoint = 'https://apps.fedoraproject.org/datagrepper/raw/'
 
     def __init__(self, config):

--- a/statscache_plugins/releng/__init__.py
+++ b/statscache_plugins/releng/__init__.py
@@ -29,6 +29,7 @@ class Plugin(statscache.plugins.BasePlugin):
 
     @property
     def layout(self):
+        # why not: layout = { ... }
         return {
             'groups': [
                 {
@@ -146,7 +147,7 @@ class Plugin(statscache.plugins.BasePlugin):
                 except Exception as e:
                     log.exception(
                         "Error in releng plugin '{}': {}".format(
-                            plugin.idx, e), exc_info=True)
+                            plugin.ident, e), exc_info=True)
             # FIXME: need to write in a single db hit
             session.add_all(rows)
             session.commit()
@@ -164,12 +165,13 @@ class Plugin(statscache.plugins.BasePlugin):
             except Exception as e:
                 log.exception(
                     "Error during initializing releng plugin '{}': {}".format(
-                        plugin.idx, e), exc_info=True)
+                        plugin.ident, e), exc_info=True)
 
     def cleanup(self):
         pass
 
     def load_plugins(self, config, model):
+        # TODO: plugins for a plugin? This shoudln't be necessary
         if getattr(self, '_plugins', None):
             return self._plugins
         self._plugins = []
@@ -179,8 +181,8 @@ class Plugin(statscache.plugins.BasePlugin):
             module = importer.find_module(
                 package_name).load_module(full_package_name)
             plugin = getattr(module, 'Plugin', None)
-            if plugin and issubclass(
-                    plugin, statscache.plugins.BasePlugin):
+            if plugin and issubclass(plugin,
+                                    statscache.plugins.BasePlugin):
                 log.info("Loading plugin %r" % plugin)
                 self._plugins.append(plugin(config, model))
             else:

--- a/statscache_plugins/releng/plugins/amis.py
+++ b/statscache_plugins/releng/plugins/amis.py
@@ -21,7 +21,7 @@ class Plugin(statscache.plugins.BasePlugin):
         super(Plugin, self).__init__(*args, **kwargs)
         self._seen = {}
 
-    def handle(self, session, messages):
+    def handle(self, session, timestamp, messages):
         rows = []
         for message in messages:
             if not (message['topic'] in self.topics and
@@ -97,6 +97,6 @@ class Plugin(statscache.plugins.BasePlugin):
                     'contains': 'completed'
                 }
             )
-            rows = self.handle(session, resp.json().get('raw_messages', []))
+            rows = self.handle(session, latest.timestamp, resp.json().get('raw_messages', []))
             session.add_all(rows)
             session.commit()

--- a/statscache_plugins/releng/plugins/artifacts.py
+++ b/statscache_plugins/releng/plugins/artifacts.py
@@ -18,7 +18,7 @@ class Plugin(statscache.plugins.BasePlugin):
         super(Plugin, self).__init__(*args, **kwargs)
         self._seen = {}
 
-    def handle(self, session, messages):
+    def handle(self, session, timestamp, messages):
         rows = []
         for message in messages:
             if not (message['msg'].get('owner') == 'masher' and
@@ -80,7 +80,7 @@ class Plugin(statscache.plugins.BasePlugin):
                 'user': 'masher'
             }
         )
-        rows = self.handle(session, resp.json().get('raw_messages', []))
+        rows = self.handle(session, latest.timestamp, resp.json().get('raw_messages', []))
         session.add_all(rows)
         session.commit()
 

--- a/statscache_plugins/releng/plugins/compose.py
+++ b/statscache_plugins/releng/plugins/compose.py
@@ -30,7 +30,7 @@ class Plugin(statscache.plugins.BasePlugin):
         super(Plugin, self).__init__(*args, **kwargs)
         self._seen = {}
 
-    def handle(self, session, messages):
+    def handle(self, session, timestamp, messages):
         rows = []
         for message in messages:
             m = self.p.match(message['topic'])
@@ -94,6 +94,6 @@ class Plugin(statscache.plugins.BasePlugin):
                 datagrepper_endpoint,
                 params=params
             )
-            rows = self.handle(session, resp.json().get('raw_messages', []))
+            rows = self.handle(session, latest.timestamp, resp.json().get('raw_messages', []))
             session.add_all(rows)
             session.commit()

--- a/statscache_plugins/releng/plugins/updates.py
+++ b/statscache_plugins/releng/plugins/updates.py
@@ -24,7 +24,7 @@ class Plugin(statscache.plugins.BasePlugin):
         super(Plugin, self).__init__(*args, **kwargs)
         self._seen = {}
 
-    def handle(self, session, messages):
+    def handle(self, session, timestamp, messages):
         log.info("In handle with %i messages" % len(messages))
         for message in messages:
             if not message['topic'] in self.topics:
@@ -87,5 +87,5 @@ class Plugin(statscache.plugins.BasePlugin):
                 }
             )
             messages = resp.json().get('raw_messages', [])
-            self.handle(session, messages)
+            self.handle(session, latest.timestamp, messages)
             session.commit()

--- a/statscache_plugins/volume/by_category.py
+++ b/statscache_plugins/volume/by_category.py
@@ -2,7 +2,6 @@ import collections
 import datetime
 
 import statscache.plugins
-import statscache.schedule
 from statscache_plugins.volume.utils import VolumePluginMixin
 
 import sqlalchemy as sa
@@ -53,14 +52,14 @@ class PluginMixin(VolumePluginMixin):
 
 
 class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(seconds=1)
+    interval = datetime.timedelta(seconds=1)
 
 
 class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(seconds=5)
+    interval = datetime.timedelta(seconds=5)
 
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(minutes=1)
+    interval = datetime.timedelta(minutes=1)
 
 plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_category.py
+++ b/statscache_plugins/volume/by_category.py
@@ -28,7 +28,7 @@ class PluginMixin(VolumePluginMixin):
                         'category': sa.Column(sa.UnicodeText, nullable=False, index=True),
                     })
 
-    def handle(self, session, messages):
+    def handle(self, session, timestamp, messages):
         volumes = collections.defaultdict(int)
         for msg in messages:
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])

--- a/statscache_plugins/volume/by_category.py
+++ b/statscache_plugins/volume/by_category.py
@@ -33,7 +33,7 @@ class PluginMixin(VolumePluginMixin):
         for msg in messages:
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])
             volumes[(msg['topic'].split('.')[3],
-                     self.frequency.next(msg_timestamp))] += 1
+                     self.frequency + msg_timestamp)] += 1
 
         for key, volume in volumes.items():
             category, timestamp = key
@@ -53,14 +53,14 @@ class PluginMixin(VolumePluginMixin):
 
 
 class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('1s')
+    frequency = statscache.plugins.Frequency(seconds=1)
 
 
 class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('5s')
+    frequency = statscache.plugins.Frequency(seconds=5)
 
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('1m')
+    frequency = statscache.plugins.Frequency(minutes=1)
 
 plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_category.py
+++ b/statscache_plugins/volume/by_category.py
@@ -62,3 +62,5 @@ class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
     frequency = statscache.schedule.Frequency('1m')
+
+plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_category.py
+++ b/statscache_plugins/volume/by_category.py
@@ -33,7 +33,7 @@ class PluginMixin(VolumePluginMixin):
         for msg in messages:
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])
             volumes[(msg['topic'].split('.')[3],
-                     self.frequency + msg_timestamp)] += 1
+                     self.frequency.next(now=msg_timestamp))] += 1
 
         for key, volume in volumes.items():
             category, timestamp = key

--- a/statscache_plugins/volume/by_package.py
+++ b/statscache_plugins/volume/by_package.py
@@ -35,7 +35,7 @@ class PluginMixin(VolumePluginMixin):
             packages = fedmsg.meta.msg2packages(msg, **self.config)
             for package in packages:
                 volumes[
-                    (package, self.frequency + msg_timestamp)] += 1
+                    (package, self.frequency.next(now=msg_timestamp))] += 1
 
         for key, volume in volumes.items():
             package, timestamp = key

--- a/statscache_plugins/volume/by_package.py
+++ b/statscache_plugins/volume/by_package.py
@@ -28,7 +28,7 @@ class PluginMixin(VolumePluginMixin):
                         'package': sa.Column(sa.UnicodeText, nullable=False, index=True),
                     })
 
-    def handle(self, session, messages):
+    def handle(self, session, timestamp, messages):
         volumes = collections.defaultdict(int)
         for msg in messages:
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])

--- a/statscache_plugins/volume/by_package.py
+++ b/statscache_plugins/volume/by_package.py
@@ -55,14 +55,14 @@ class PluginMixin(VolumePluginMixin):
 
 
 class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(seconds=1)
+    interval = datetime.timedelta(seconds=1)
 
 
 class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(seconds=5)
+    interval = datetime.timedelta(seconds=5)
 
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(minutes=1)
+    interval = datetime.timedelta(minutes=1)
 
 plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_package.py
+++ b/statscache_plugins/volume/by_package.py
@@ -64,3 +64,5 @@ class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
     frequency = statscache.schedule.Frequency('1m')
+
+plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_package.py
+++ b/statscache_plugins/volume/by_package.py
@@ -35,7 +35,7 @@ class PluginMixin(VolumePluginMixin):
             packages = fedmsg.meta.msg2packages(msg, **self.config)
             for package in packages:
                 volumes[
-                    (package, self.frequency.next(msg_timestamp))] += 1
+                    (package, self.frequency + msg_timestamp)] += 1
 
         for key, volume in volumes.items():
             package, timestamp = key
@@ -55,14 +55,14 @@ class PluginMixin(VolumePluginMixin):
 
 
 class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('1s')
+    frequency = statscache.plugins.Frequency(seconds=1)
 
 
 class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('5s')
+    frequency = statscache.plugins.Frequency(seconds=5)
 
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('1m')
+    frequency = statscache.plugins.Frequency(minutes=1)
 
 plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_topic.py
+++ b/statscache_plugins/volume/by_topic.py
@@ -27,7 +27,7 @@ class PluginMixin(VolumePluginMixin):
                         'topic': sa.Column(sa.UnicodeText, nullable=False, index=True),
                     })
 
-    def handle(self, session, messages):
+    def handle(self, session, timestamp, messages):
         volumes = collections.defaultdict(int)
         for msg in messages:
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])

--- a/statscache_plugins/volume/by_topic.py
+++ b/statscache_plugins/volume/by_topic.py
@@ -32,7 +32,7 @@ class PluginMixin(VolumePluginMixin):
         for msg in messages:
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])
             volumes[(msg['topic'],
-                     self.frequency + msg_timestamp)] += 1
+                     self.frequency.next(now=msg_timestamp))] += 1
 
         for key, volume in volumes.items():
             topic, timestamp = key

--- a/statscache_plugins/volume/by_topic.py
+++ b/statscache_plugins/volume/by_topic.py
@@ -32,7 +32,7 @@ class PluginMixin(VolumePluginMixin):
         for msg in messages:
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])
             volumes[(msg['topic'],
-                     self.frequency.next(msg_timestamp))] += 1
+                     self.frequency + msg_timestamp)] += 1
 
         for key, volume in volumes.items():
             topic, timestamp = key
@@ -52,14 +52,14 @@ class PluginMixin(VolumePluginMixin):
 
 
 class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('1s')
+    frequency = statscache.plugins.Frequency(seconds=1)
 
 
 class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('5s')
+    frequency = statscache.plugins.Frequency(seconds=5)
 
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('1m')
+    frequency = statscache.plugins.Frequency(minutes=1)
 
 plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_topic.py
+++ b/statscache_plugins/volume/by_topic.py
@@ -52,14 +52,14 @@ class PluginMixin(VolumePluginMixin):
 
 
 class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(seconds=1)
+    interval = datetime.timedelta(seconds=1)
 
 
 class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(seconds=5)
+    interval = datetime.timedelta(seconds=5)
 
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(minutes=1)
+    interval = datetime.timedelta(minutes=1)
 
 plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_topic.py
+++ b/statscache_plugins/volume/by_topic.py
@@ -61,3 +61,5 @@ class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
     frequency = statscache.schedule.Frequency('1m')
+
+plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_user.py
+++ b/statscache_plugins/volume/by_user.py
@@ -63,3 +63,5 @@ class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
     frequency = statscache.schedule.Frequency('1m')
+
+plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_user.py
+++ b/statscache_plugins/volume/by_user.py
@@ -34,7 +34,7 @@ class PluginMixin(VolumePluginMixin):
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])
             users = fedmsg.meta.msg2usernames(msg, **self.config)
             for user in users:
-                volumes[(user, self.frequency + msg_timestamp)] += 1
+                volumes[(user, self.frequency.next(now=msg_timestamp))] += 1
 
         for key, volume in volumes.items():
             user, timestamp = key

--- a/statscache_plugins/volume/by_user.py
+++ b/statscache_plugins/volume/by_user.py
@@ -54,14 +54,14 @@ class PluginMixin(VolumePluginMixin):
 
 
 class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(seconds=1)
+    interval = datetime.timedelta(seconds=1)
 
 
 class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(seconds=5)
+   interval = datetime.timedelta(seconds=5)
 
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(minutes=1)
+    interval = datetime.timedelta(minutes=1)
 
 plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/by_user.py
+++ b/statscache_plugins/volume/by_user.py
@@ -28,7 +28,7 @@ class PluginMixin(VolumePluginMixin):
                         'user': sa.Column(sa.UnicodeText, nullable=False, index=True),
                     })
 
-    def handle(self, session, messages):
+    def handle(self, session, timestamp, messages):
         volumes = collections.defaultdict(int)
         for msg in messages:
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])

--- a/statscache_plugins/volume/by_user.py
+++ b/statscache_plugins/volume/by_user.py
@@ -34,7 +34,7 @@ class PluginMixin(VolumePluginMixin):
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])
             users = fedmsg.meta.msg2usernames(msg, **self.config)
             for user in users:
-                volumes[(user, self.frequency.next(msg_timestamp))] += 1
+                volumes[(user, self.frequency + msg_timestamp)] += 1
 
         for key, volume in volumes.items():
             user, timestamp = key
@@ -54,14 +54,14 @@ class PluginMixin(VolumePluginMixin):
 
 
 class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('1s')
+    frequency = statscache.plugins.Frequency(seconds=1)
 
 
 class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('5s')
+    frequency = statscache.plugins.Frequency(seconds=5)
 
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('1m')
+    frequency = statscache.plugins.Frequency(minutes=1)
 
 plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/simple.py
+++ b/statscache_plugins/volume/simple.py
@@ -2,7 +2,6 @@ import collections
 import datetime
 
 import statscache.plugins
-import statscache.schedule
 from statscache_plugins.volume.utils import VolumePluginMixin
 
 
@@ -46,14 +45,14 @@ class PluginMixin(VolumePluginMixin):
 
 
 class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(seconds=1)
+    interval = datetime.timedelta(seconds=1)
 
 
 class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(seconds=5)
+    interval = datetime.timedelta(seconds=5)
 
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.plugins.Frequency(minutes=1)
+    interval = datetime.timedelta(minutes=1)
 
 plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/simple.py
+++ b/statscache_plugins/volume/simple.py
@@ -25,7 +25,7 @@ class PluginMixin(VolumePluginMixin):
                         '__tablename__': 'data_volume_' + freq,
                     })
 
-    def handle(self, session, messages):
+    def handle(self, session, timestamp, messages):
         volumes = collections.defaultdict(int)
         for msg in messages:
             msg_timestamp = datetime.datetime.fromtimestamp(msg['timestamp'])

--- a/statscache_plugins/volume/simple.py
+++ b/statscache_plugins/volume/simple.py
@@ -46,14 +46,14 @@ class PluginMixin(VolumePluginMixin):
 
 
 class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('1s')
+    frequency = statscache.plugins.Frequency(seconds=1)
 
 
 class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('5s')
+    frequency = statscache.plugins.Frequency(seconds=5)
 
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    frequency = statscache.schedule.Frequency('1m')
+    frequency = statscache.plugins.Frequency(minutes=1)
 
 plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/simple.py
+++ b/statscache_plugins/volume/simple.py
@@ -55,3 +55,5 @@ class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
 
 class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
     frequency = statscache.schedule.Frequency('1m')
+
+plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]

--- a/statscache_plugins/volume/utils.py
+++ b/statscache_plugins/volume/utils.py
@@ -14,7 +14,7 @@ class VolumePluginMixin(object):
             session.commit()
             delta = int(
                 (datetime.datetime.now() -
-                 self.frequency.prev(latest.timestamp)).total_seconds()
+                 latest.timestamp - self.frequency).total_seconds()
             )
         resp = requests.get(
             self.datagrepper_endpoint,

--- a/statscache_plugins/volume/utils.py
+++ b/statscache_plugins/volume/utils.py
@@ -23,4 +23,4 @@ class VolumePluginMixin(object):
                 'rows_per_page': 100
             }
         )
-        self.handle(session, resp.json().get('raw_messages', []))
+        self.handle(session, latest.timestamp, resp.json().get('raw_messages', []))

--- a/statscache_plugins/volume/utils.py
+++ b/statscache_plugins/volume/utils.py
@@ -14,7 +14,7 @@ class VolumePluginMixin(object):
             session.commit()
             delta = int(
                 (datetime.datetime.now() -
-                 latest.timestamp - self.frequency).total_seconds()
+                 self.frequency.last(now=latest.timestamp)).total_seconds()
             )
         resp = requests.get(
             self.datagrepper_endpoint,

--- a/tests/test_releng.py
+++ b/tests/test_releng.py
@@ -1,4 +1,6 @@
 import unittest
+import datetime
+import statscache.frequency
 import statscache.plugins
 import statscache_plugins.releng
 
@@ -18,6 +20,12 @@ class TestRelengPlugin(unittest.TestCase):
         return statscache.plugins.init_model(uri)
 
     def test_init(self):
-        plugin = statscache_plugins.releng.Plugin(self.config)
+        frequency = statscache.frequency.Frequency(
+            statscache_plugins.releng.Plugin.interval,
+            datetime.datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0))
+        plugin = statscache_plugins.releng.Plugin(frequency, self.config)
         session = self._make_session()
         plugin.initialize(session)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -1,4 +1,6 @@
 import unittest
+import datetime
+import statscache.frequency
 import statscache.plugins
 import statscache_plugins.volume.by_category
 from sqlalchemy import create_engine
@@ -19,7 +21,11 @@ class TestVolumePlugin(unittest.TestCase):
         return statscache.plugins.init_model(uri)
 
     def test_init(self):
-        plugin = statscache_plugins.volume.by_category.OneMinuteFrequencyPlugin(self.config)
+        frequency = statscache.frequency.Frequency(
+            statscache_plugins.volume.by_category.OneMinuteFrequencyPlugin.interval,
+            datetime.datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0))
+        plugin = statscache_plugins.volume.by_category.OneMinuteFrequencyPlugin(frequency,
+                                                                                self.config)
         session = self._make_session()
         plugin.initialize(session)
 


### PR DESCRIPTION
This change set updates the currently available plugins to specify their desired running frequency using the new `statscache.plugins.Frequency` class and to accept a cache timestamp in their `handle()` methods. Note that the `statscache_plugins.releng.Plugin` class did not have any indication of what frequency to use (that I could see), and so I arbitrarily chose 5 minutes for testing.

This pull request restores compatibility with its partner request to the [main statscache engine](https://github.com/fedora-infra/statscache/pull/18).
