### PR TITLE
Refactor model class creation out of plugin initialization

### DIFF
--- a/statscache_plugins/releng/__init__.py
+++ b/statscache_plugins/releng/__init__.py
@@ -23,11 +23,10 @@ class Plugin(statscache.plugins.BasePlugin):
         self._plugins = None
         self._plugins = self.load_plugins()
 
-    def make_model(self):
-        class Result(statscache.plugins.ConstrainedCategorizedLogModel):
+    class Model(statscache.plugins.ConstrainedCategorizedLogModel):
             __tablename__ = 'data_releng_dashboard'
 
-        return Result
+    model = Model
 
     @property
     def layout(self):

--- a/statscache_plugins/volume/by_category.py
+++ b/statscache_plugins/volume/by_category.py
@@ -1,8 +1,7 @@
 import collections
 import datetime
 
-import statscache.plugins
-from statscache_plugins.volume.utils import VolumePluginMixin
+from statscache_plugins.volume.utils import VolumePluginMixin, plugin_factory
 
 import sqlalchemy as sa
 
@@ -14,18 +13,6 @@ class PluginMixin(VolumePluginMixin):
     For any given time window, the number of messages that come across
     the bus for each category.
     """
-
-    def make_model(self):
-        freq = str(self.frequency)
-
-        return type('VolumeByCategory' + freq + 'Model',
-                    (statscache.plugins.BaseModel,),
-                    {
-                        '__tablename__': 'data_volume_by_category_' + freq,
-                        'timestamp': sa.Column(sa.DateTime, nullable=False, index=True),
-                        'volume': sa.Column(sa.Integer, nullable=False),
-                        'category': sa.Column(sa.UnicodeText, nullable=False, index=True),
-                    })
 
     def handle(self, session, messages):
         volumes = collections.defaultdict(int)
@@ -51,15 +38,13 @@ class PluginMixin(VolumePluginMixin):
             session.commit()
 
 
-class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(seconds=1)
-
-
-class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(seconds=5)
-
-
-class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(minutes=1)
-
-plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]
+plugins = plugin_factory(
+    [datetime.timedelta(seconds=s) for s in [1, 5, 60]],
+    PluginMixin,
+    "VolumeByCategory",
+    "data_volume_by_category_",
+    columns={
+        'volume': sa.Column(sa.Integer, nullable=False),
+        'category': sa.Column(sa.UnicodeText, nullable=False, index=True),
+    }
+)

--- a/statscache_plugins/volume/by_package.py
+++ b/statscache_plugins/volume/by_package.py
@@ -1,8 +1,7 @@
 import collections
 import datetime
 
-import statscache.plugins
-from statscache_plugins.volume.utils import VolumePluginMixin
+from statscache_plugins.volume.utils import VolumePluginMixin, plugin_factory
 
 import fedmsg.meta
 import sqlalchemy as sa
@@ -15,18 +14,6 @@ class PluginMixin(VolumePluginMixin):
     For any given time window, the number of messages that come across
     the bus for each package.
     """
-
-    def make_model(self):
-        freq = str(self.frequency)
-
-        return type('VolumeByPackage' + freq + 'Model',
-                    (statscache.plugins.BaseModel,),
-                    {
-                        '__tablename__': 'data_volume_by_package_' + freq,
-                        'timestamp': sa.Column(sa.DateTime, nullable=False, index=True),
-                        'volume': sa.Column(sa.Integer, nullable=False),
-                        'package': sa.Column(sa.UnicodeText, nullable=False, index=True),
-                    })
 
     def handle(self, session, messages):
         volumes = collections.defaultdict(int)
@@ -54,15 +41,13 @@ class PluginMixin(VolumePluginMixin):
         session.commit()
 
 
-class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(seconds=1)
-
-
-class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(seconds=5)
-
-
-class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(minutes=1)
-
-plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]
+plugins = plugin_factory(
+    [datetime.timedelta(seconds=s) for s in [1, 5, 60]],
+    PluginMixin,
+    "VolumeByPackage",
+    "data_volume_by_package_",
+    columns={
+        'volume': sa.Column(sa.Integer, nullable=False),
+        'package': sa.Column(sa.UnicodeText, nullable=False, index=True),
+    }
+)

--- a/statscache_plugins/volume/by_topic.py
+++ b/statscache_plugins/volume/by_topic.py
@@ -1,8 +1,7 @@
 import collections
 import datetime
 
-import statscache.plugins
-from statscache_plugins.volume.utils import VolumePluginMixin
+from statscache_plugins.volume.utils import VolumePluginMixin, plugin_factory
 
 import sqlalchemy as sa
 
@@ -14,18 +13,6 @@ class PluginMixin(VolumePluginMixin):
     For any given time window, the number of messages that come across
     the bus for each topic.
     """
-
-    def make_model(self):
-        freq = str(self.frequency)
-
-        return type('VolumeByTopic' + freq + 'Model',
-                    (statscache.plugins.BaseModel,),
-                    {
-                        '__tablename__': 'data_volume_by_topic_' + freq,
-                        'timestamp': sa.Column(sa.DateTime, nullable=False, index=True),
-                        'volume': sa.Column(sa.Integer, nullable=False),
-                        'topic': sa.Column(sa.UnicodeText, nullable=False, index=True),
-                    })
 
     def handle(self, session, messages):
         volumes = collections.defaultdict(int)
@@ -51,15 +38,13 @@ class PluginMixin(VolumePluginMixin):
         session.commit()
 
 
-class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(seconds=1)
-
-
-class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(seconds=5)
-
-
-class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(minutes=1)
-
-plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]
+plugins = plugin_factory(
+    [datetime.timedelta(seconds=s) for s in [1, 5, 60]],
+    PluginMixin,
+    "VolumeByTopic",
+    "data_volume_by_topic_",
+    columns={
+        'volume': sa.Column(sa.Integer, nullable=False),
+        'topic': sa.Column(sa.UnicodeText, nullable=False, index=True),
+    }
+)

--- a/statscache_plugins/volume/simple.py
+++ b/statscache_plugins/volume/simple.py
@@ -1,8 +1,7 @@
 import collections
 import datetime
 
-import statscache.plugins
-from statscache_plugins.volume.utils import VolumePluginMixin
+from statscache_plugins.volume.utils import VolumePluginMixin, plugin_factory
 
 
 class PluginMixin(VolumePluginMixin):
@@ -14,15 +13,6 @@ class PluginMixin(VolumePluginMixin):
     It can give you a baseline quantity against which you could normalize
     other statistics.
     """
-
-    def make_model(self):
-        freq = str(self.frequency)
-
-        return type('Volume' + freq + 'Model',
-                    (statscache.plugins.ScalarModel,),
-                    {
-                        '__tablename__': 'data_volume_' + freq,
-                    })
 
     def handle(self, session, messages):
         volumes = collections.defaultdict(int)
@@ -44,15 +34,9 @@ class PluginMixin(VolumePluginMixin):
         session.commit()
 
 
-class OneSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(seconds=1)
-
-
-class FiveSecondFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(seconds=5)
-
-
-class OneMinuteFrequencyPlugin(PluginMixin, statscache.plugins.BasePlugin):
-    interval = datetime.timedelta(minutes=1)
-
-plugins = [OneSecondFrequencyPlugin, FiveSecondFrequencyPlugin, OneMinuteFrequencyPlugin]
+plugins = plugin_factory(
+    [datetime.timedelta(seconds=s) for s in [1, 5, 60]],
+    PluginMixin,
+    "Volume",
+    "data_volume_"
+)

--- a/statscache_plugins/volume/utils.py
+++ b/statscache_plugins/volume/utils.py
@@ -1,5 +1,8 @@
 import datetime
 import requests
+import copy
+from statscache.frequency import Frequency
+from statscache.plugins import BasePlugin, BaseModel, ScalarModel
 
 
 class VolumePluginMixin(object):
@@ -24,3 +27,21 @@ class VolumePluginMixin(object):
             }
         )
         self.handle(session, resp.json().get('raw_messages', []))
+
+
+def plugin_factory(intervals, plugin_mixin_class, class_prefix, table_prefix,
+                   columns=None):
+    for interval in intervals:
+        s = str(Frequency(interval)) # pretty-print timedelta
+        class PluginAnon(plugin_mixin_class, BasePlugin):
+            pass
+        PluginAnon.__name__ = s.join([class_prefix, "Plugin"])
+        PluginAnon.interval = interval
+        modelAttributes = { '__tablename__': table_prefix + s }
+        modelAttributes.update(copy.deepcopy(columns or {}))
+        PluginAnon.model = type(
+            s.join([class_prefix, "Model"]),
+            (BaseModel if columns is not None else ScalarModel,),
+            modelAttributes
+        )
+        yield PluginAnon


### PR DESCRIPTION
Removes the `make_model()` method from all plugins, instead replacing it with a `model` attribute set to the model class. For the generic volume plugins, a utility plugin and model class factory is used to avoid the need for excessive biolerplate code.

This pull request is complementary to [another](https://github.com/fedora-infra/statscache/pull/27) submitted to `statscache` proper.
