### PR TITLE
Add missing import

### DIFF
--- a/statscache_plugins/volume/simple.py
+++ b/statscache_plugins/volume/simple.py
@@ -2,6 +2,8 @@ import datetime
 
 from statscache_plugins.volume.utils import VolumePluginMixin, plugin_factory
 
+import sqlalchemy as sa
+
 
 class PluginMixin(VolumePluginMixin):
     name = "volume"


### PR DESCRIPTION
Not sure how this slipped by me yesterday, but SQLAlchemy needs to be imported in order to be used.
