### PR TITLE
Suppress common error in releng artifacts

### DIFF
--- a/statscache_plugins/releng/plugins/artifacts.py
+++ b/statscache_plugins/releng/plugins/artifacts.py
@@ -42,7 +42,7 @@ class Plugin(statscache.plugins.BasePlugin):
             'link': link,
             'status': message['msg']['new'],
             'extra_text': '(details)',
-            'extra_link': message['meta']['link']
+            'extra_link': message.get('meta', { 'link': None })['link']
         })
         self._queue[(category, category_constraint)] = (timestamp, msg)
 


### PR DESCRIPTION
The `releng-artifacts` plugin commonly fails during message processing with a
`KeyError` from the key `meta` in the message dictionary. This suppresses such
errors in favor of providing `None` for the desired sub-key.

I'm not quite sure if there's a more serious problem at play other than the meta information not being provided consistently, but this error can come up quite often in long running instances and gets pretty irritating. If there is a root cause that should be investigated, please do point me in the right direction :)
