### PR TITLE
Testsuite fixes

### DIFF
--- a/statscache_plugins/releng/__init__.py
+++ b/statscache_plugins/releng/__init__.py
@@ -155,17 +155,6 @@ class Plugin(statscache.plugins.BasePlugin):
                         plugin.ident, e), exc_info=True)
                 session.rollback()
 
-    def initialize(self, session):
-        for plugin in self._plugins:
-            if getattr(plugin, 'initialize', None) is None:
-                continue
-            try:
-                plugin.initialize(session, self.datagrepper_endpoint)
-            except Exception as e:
-                log.exception(
-                    "Error during initializing releng plugin '{}': {}".format(
-                        plugin.ident, e), exc_info=True)
-
     def cleanup(self):
         pass
 

--- a/tests/test_releng.py
+++ b/tests/test_releng.py
@@ -2,7 +2,6 @@ import unittest
 import datetime
 import statscache.utils
 import statscache.plugins
-import statscache.plugins.schedule
 import statscache_plugins.releng
 
 
@@ -21,11 +20,8 @@ class TestRelengPlugin(unittest.TestCase):
         return statscache.utils.init_model(uri)
 
     def test_init(self):
-        schedule = statscache.plugins.schedule.Schedule(
-            interval=datetime.timedelta(minutes=5))
-        plugin = statscache_plugins.releng.Plugin(schedule, self.config)
-        session = self._make_session()
-        plugin.initialize(session)
+        """ Test the ability of the releng plugin(s) to initialize """
+        return statscache_plugins.releng.Plugin(None, self.config)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_volume.py
+++ b/tests/test_volume.py
@@ -2,7 +2,6 @@ import unittest
 import datetime
 import statscache.utils
 import statscache.plugins
-import statscache.plugins.schedule
 import statscache_plugins.volume.by_category
 
 
@@ -21,12 +20,10 @@ class TestVolumePlugin(unittest.TestCase):
         return statscache.utils.init_model(uri)
 
     def test_init(self):
-        schedule = statscache.plugins.schedule.Schedule(
-            interval=datetime.timedelta(minutes=1))
-        plugins = statscache_plugins.volume.by_category.plugins
-        plugin = list(plugins)[0](schedule, self.config)
-        #session = self._make_session()
-        #plugin.fill(session) ... # we should test things like this and other behaviors.
+        """ Test the ability of an arbitrary volume plugin to initialize itself """
+        plugin_class = list(statscache_plugins.volume.by_category.plugins)[-1]
+        schedule = statscache.plugins.Schedule(interval=plugin_class.interval)
+        return plugin_class(schedule, self.config)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Clean up the testsuite for plugins and remove some dead code that oddly got left lying around. Also, since neither the releng nor the volume plugin(s) utilize work queues, there's be no point in testing the method on them.

To clarify, the `initialize()` method of the releng master plugin was not called from any other point in the code and did not perform any useful function, as the `initialize()` virtual method of plugins was split up into other methods. In this case, all the code was doing was calling the same method on child plugins, none of which actually had any such method of their own.
